### PR TITLE
Improve customizability

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.ssh.forward_agent = true
 
-  config.vm.synced_folder ".", "/var/www", type: "nfs", mount_options: ['rw', 'vers=3', 'tcp', 'fsc']
+  config.vm.synced_folder "./", "/var/www", type: "nfs", mount_options: ['rw', 'vers=3', 'tcp', 'fsc']
 
   config.vm.provider "virtualbox" do |vb|
     vb.customize ["modifyvm", :id, "--memory", CONF["ram"]]
@@ -25,7 +25,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ["modifyvm", :id, "--name", CONF["name"]]
   end
 
-  config.vm.provision :shell, :path => "scripts/install-ansible.sh"
-  config.vm.provision :shell, :path => "scripts/run-ansible.sh"
+  config.vm.provision :shell, :path => "scripts/install-ansible.sh", :args => "/var/www"
+  config.vm.provision :shell, :path => "scripts/run-ansible.sh", :args => "/var/www"
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = ubuntu/precise64
+  config.vm.box = "ubuntu/precise64"
 
   config.vm.network "private_network", ip: CONF["ipaddress"]
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,8 +10,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  # ubuntu 12.04 LTS
-  config.vm.box = CONF["box"]
+  config.vm.box = ubuntu/precise64
 
   config.vm.network "private_network", ip: CONF["ipaddress"]
 

--- a/scripts/install-ansible.sh
+++ b/scripts/install-ansible.sh
@@ -31,7 +31,7 @@ fi
 
 printf '**************************\n\n'
 printf 'Removes executable permission on hosts.ini to avoid ansible evalute this inventory like external scritp'
-chmod -x /var/www/provisioning/hosts.ini
+chmod -x $1/provisioning/hosts.ini
 printf '**************************\n\n'
 
 

--- a/scripts/run-ansible.sh
+++ b/scripts/run-ansible.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 echo Running ansible playbooks as local
-ansible-playbook /var/www/provisioning/playbooks.yml -i /var/www/provisioning/hosts.ini --connection=local
+ansible-playbook $1/provisioning/playbooks.yml -i $1/provisioning/hosts.ini --connection=local
 

--- a/vagrantconfig.dist.yml
+++ b/vagrantconfig.dist.yml
@@ -1,4 +1,3 @@
-box:        ubuntu/precise64
 ram:        2048
 cpus:       2
 ipaddress:  10.10.10.10


### PR DESCRIPTION
I have refactored the provisioning scripts to accept a parameter that is used to compose path within the scripts itself. This allow to customize the shared directory without having to update any provisioning scripts.

I also have removed the box name from the external config file. Vagrantfile is a configuration file itself (a little more than that, but not too much), I think we should use the external yaml file  only for params that a single developer may want to customize for his needs. The boxname is not one of them, each developer **must** use the same box, in order to ensure the correct environment. 