### PR TITLE
Adds env variable for unbuffered output

### DIFF
--- a/scripts/install-ansible.sh
+++ b/scripts/install-ansible.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+export DEBIAN_FRONTEND=noninteractive
+export PYTHONUNBUFFERED=1
+
 sudo apt-get update
 
 printf '**************************\n\n'

--- a/scripts/run-ansible.sh
+++ b/scripts/run-ansible.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+export DEBIAN_FRONTEND=noninteractive
+export PYTHONUNBUFFERED=1
+
 echo Running ansible playbooks as local
 ansible-playbook $1/provisioning/playbooks.yml -i $1/provisioning/hosts.ini --connection=local
 


### PR DESCRIPTION
`DEBIAN_FRONTEND`env var prevents for getting error "stdin: not a tty" during vagrant provision

`PYTHONUNBUFFERED=1`env var disables output buffering when running ansible for faster feedback to users
