### PR TITLE
get_url, variable ordering and Apache2 template

### DIFF
--- a/provisioning/ideato.database.mysql/defaults/main.yml
+++ b/provisioning/ideato.database.mysql/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+ideato_mysql_user: ideato
+ideato_mysql_password: ideato
+ideato_mysql_db: db_ideato

--- a/provisioning/ideato.database.mysql/vars/main.yml
+++ b/provisioning/ideato.database.mysql/vars/main.yml
@@ -1,4 +1,1 @@
----
-ideato_mysql_user: ideato
-ideato_mysql_password: ideato
-ideato_mysql_db: db_ideato
+# vars file for ideato.database.mysql

--- a/provisioning/ideato.webserver/defaults/main.yml
+++ b/provisioning/ideato.webserver/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+
+#customize apache and virtual host
+apache_user: vagrant
+server_name_virtual_host: ideato2.dev
+application_root_dir: /var/www
+
+php_ppa_54: php5-oldstable
+#php_ppa: php5
+php_ppa: php5-5.6

--- a/provisioning/ideato.webserver/tasks/main.yml
+++ b/provisioning/ideato.webserver/tasks/main.yml
@@ -8,6 +8,13 @@
   template: src=apache/virtual_host.j2
         dest=/etc/apache2/sites-available/virtual_host.conf
         owner=root group=root mode=644 backup=yes
+  when: ansible_distribution_release == "precise"
+
+- name: create virtual host24
+  template: src=apache/virtual_host24.j2
+        dest=/etc/apache2/sites-available/virtual_host.conf
+        owner=root group=root mode=644 backup=yes
+  when: ansible_distribution_release == "trusty"
 
 - name: enable development site
   command: a2ensite virtual_host.conf

--- a/provisioning/ideato.webserver/tasks/main.yml
+++ b/provisioning/ideato.webserver/tasks/main.yml
@@ -90,7 +90,7 @@
   file: path=/usr/bin/phing state=link src=/home/vagrant/.composer/vendor/bin/phing
 
 - name: Install idephix
-  shell: chdir=/tmp curl http://getidephix.com/idephix.phar > idephix.phar
+  get_url: url=http://getidephix.com/idephix.phar dest=/tmp/idephix.phar
 
 - name: Copy idephix to bin dir
   command: chdir=/tmp creates=/usr/bin/idx mv idephix.phar /usr/bin/idx

--- a/provisioning/ideato.webserver/templates/apache/virtual_host24.j2
+++ b/provisioning/ideato.webserver/templates/apache/virtual_host24.j2
@@ -1,0 +1,11 @@
+<VirtualHost *:80>
+    ServerName {{ server_name_virtual_host }}
+    DocumentRoot "{{ application_root_dir }}"
+
+    CustomLog /var/log/apache2/virtual_host-access.log combined
+    ErrorLog /var/log/apache2/virtual_host-error.log
+    <Directory "{{ application_root_dir }}">
+        AllowOverride All
+        Require all granted
+    </Directory>
+</VirtualHost>

--- a/provisioning/ideato.webserver/vars/main.yml
+++ b/provisioning/ideato.webserver/vars/main.yml
@@ -1,10 +1,1 @@
----
-
-#customize apache and virtual host
-apache_user: vagrant
-server_name_virtual_host: ideato2.dev
-application_root_dir: /var/www
-
-php_ppa_54: php5-oldstable
-#php_ppa: php5
-php_ppa: php5-5.6
+# vars file for ideato.webserver


### PR DESCRIPTION
use Ansible get_url module instead curl, using curl downloading idephix often fails

variable ordering: following Ansible best practices we should put default variables on /default directory instead on /var. Otherwise if we define an external variable file, we cannot use it

added Apache 2.4 template for trusty 