### PR TITLE
Avoid login screen in phpmyadmin and allow auto login

### DIFF
--- a/provisioning/ideato.database.mysql/tasks/main.yml
+++ b/provisioning/ideato.database.mysql/tasks/main.yml
@@ -40,3 +40,15 @@
             value=1
             backup=yes
   notify: restart mysql
+
+- name: Install phpmyadmin
+  apt: pkg=phpmyadmin state=present
+
+- name: Include phpmyadmin config file into Apache config file
+  lineinfile: dest=/etc/apache2/apache2.conf line="Include /etc/phpmyadmin/apache.conf"
+  notify: restart apache
+
+- name: "Avoid login screen in phpmyadmin and auto login"
+  template:
+    src: "phpmyadmin/config.auth_type.php"
+    dest: "/etc/phpmyadmin/conf.d"

--- a/provisioning/ideato.database.mysql/templates/phpmyadmin/config.auth_type.php
+++ b/provisioning/ideato.database.mysql/templates/phpmyadmin/config.auth_type.php
@@ -1,0 +1,6 @@
+<?php
+
+//avoid login screen in phpmyadmin and auto login
+$cfg['Servers'][$i]['auth_type']    = 'config';
+$cfg['Servers'][$i]['user']         = '{{ ideato_mysql_user }}';
+$cfg['Servers'][$i]['password']     = '{{ ideato_mysql_password }}';

--- a/provisioning/ideato.webserver/tasks/main.yml
+++ b/provisioning/ideato.webserver/tasks/main.yml
@@ -93,7 +93,7 @@
   template:
     src: "composer/auth.json.j2"
     dest: "{{ composer_home_path|default('/home/vagrant/.composer/') }}/auth.json"
-    owner: vagrant 
+    owner: vagrant
     group: vagrant
   when: composer_github_oauth != false
 
@@ -132,10 +132,3 @@
 
 - name: Symlink php-cs-fixer to bin dir
   file: path=/usr/bin/php-cs-fixer state=link src=/home/vagrant/.composer/vendor/bin/php-cs-fixer
-
-- name: Install phpmyadmin
-  apt: pkg=phpmyadmin state=present
-
-- name: Include phpmyadmin config file into Apache config file
-  lineinfile: dest=/etc/apache2/apache2.conf line="Include /etc/phpmyadmin/apache.conf"
-  notify: restart apache


### PR DESCRIPTION
This PR enables auto login in phpMyAdmin. I also moved the phpMyAdmin installation from `ideato.webserver` role to `ideato.database.mysql` since I needed to use MySQL user and password.
