### PR TITLE
Add SYMFONY__USE_SHM evn variable

### DIFF
--- a/provisioning/ideato.common/tasks/dev.yml
+++ b/provisioning/ideato.common/tasks/dev.yml
@@ -12,3 +12,6 @@
     - git
     - curl
     - vim
+    
+- name: Set SYMFONY__USE_SHM environment variable
+  lineinfile: dest=/etc/environment line='SYMFONY__USE_SHM="true"'


### PR DESCRIPTION
defining this env variable we'll be able to move cache and log dir to shared memory only for development virtual machine.

Here is an example of the modified AppKernel that is using that env variables:

``` php
public function getCacheDir()
    {
        if (getenv('SYMFONY__USE_SHM')) {
            return '/dev/shm/site/cache/' . $this->environment;
        }

        return parent::getCacheDir();
    }

    public function getLogDir()
    {
        if (getenv('SYMFONY__USE_SHM')) {
            return '/dev/shm/site/logs';
        }

        return parent::getLogDir();
    }
```

We may want to use a more generic env variable name though
